### PR TITLE
Fix for concurrentModificationException in versioned settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## Changelog
 
+### v.2.5.151
+- `FIXED` : Fix thread safety issue causing concurrentModificationException with teamcity versioned settings
+
 ### v.2.5.150
-- ADDED` : Added webhook notification for slack and team app
+- `ADDED` : Added webhook notification for slack and team app
 
 ### v.2.5.144
-- ADDED` : Added No data/ Not set Condition
+- `ADDED` : Added No data/ Not set Condition
 
 ### v.2.5.138
-- ADDED` : Added Report Name in Advance Option
+- `ADDED` : Added Report Name in Advance Option
 
 ### v.2.5.132
 - `ADDED` : Server Report url for FunctionalGui tests

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <teamcity-version>9.0</teamcity-version>
-        <jenkins.build.number>150</jenkins.build.number>
+        <jenkins.build.number>151</jenkins.build.number>
     </properties>
     <groupId>com.blazemeter.teamcity</groupId>
     <artifactId>blazemeterplugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <repositories>
         <repository>
             <id>jetbrains-all</id>
-            <url>http://download.jetbrains.com/teamcity-repository</url>
+            <url>https://download.jetbrains.com/teamcity-repository</url>
         </repository>
     </repositories>
 
@@ -69,8 +69,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
             </plugins>

--- a/server/src/main/java/com/blaze/runner/BlazeRunType.java
+++ b/server/src/main/java/com/blaze/runner/BlazeRunType.java
@@ -37,8 +37,6 @@ public class BlazeRunType extends RunType {
     @NotNull
     private final String viewParamsPageName = "viewBlazeRunnerParams.jsp";
 
-    Map<String, String> defaultProperties = null;
-
     private AdminSettings pluginSettings;
 
     public BlazeRunType(final RunTypeRegistry runTypeRegistry,
@@ -67,23 +65,11 @@ public class BlazeRunType extends RunType {
 
     @Nullable
     public Map<String, String> getDefaultRunnerProperties() {
-        if (defaultProperties == null) {
-            defaultProperties = new HashMap<>();
-        }
-        setupDefaultProperties(defaultProperties);
-        return defaultProperties;
-    }
-
-    private void setupDefaultProperties(Map<String, String> params) {
-
-        if (pluginSettings != null) {
-            params.remove(Constants.API_KEY_ID);
-            params.remove(Constants.API_KEY_SECRET);
-            params.remove(Constants.BLAZEMETER_URL);
-            params.put(Constants.API_KEY_ID, pluginSettings.getApiKeyID());
-            params.put(Constants.API_KEY_SECRET, pluginSettings.getApiKeySecret());
-            params.put(Constants.BLAZEMETER_URL, pluginSettings.getBlazeMeterUrl());
-        }
+        final Map<String, String> defaultProps = new HashMap<String, String>();
+        defaultProps.put(Constants.API_KEY_ID, pluginSettings.getApiKeyID());
+        defaultProps.put(Constants.API_KEY_SECRET, pluginSettings.getApiKeySecret());
+        defaultProps.put(Constants.BLAZEMETER_URL, pluginSettings.getBlazeMeterUrl());
+        return defaultProps;
     }
 
     @Nullable


### PR DESCRIPTION
This is just copying a pattern I've nicked from plugins I know to be stable, for example: https://github.com/JetBrains/TeamCity.SonarQubePlugin/blob/26848a8526eeef0b76fa699b980482449b7a5ce7/sonar-plugin-server/src/main/java/jetbrains/buildserver/sonarplugin/sqrunner/SQRRunType.java#L76

I'm not sure why blazemeter implemented it differently, there may be a reason...

Also updated the jetbrains teamcity repository url, http is blocked by newer versions so it needs to be https.